### PR TITLE
corrected issue #199 and improve #200

### DIFF
--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -18,15 +18,29 @@
 
 #include "Arduino.h"
 #include "wiring_private.h"
-
 #include <string.h>
 
-static voidFuncPtr callbacksInt[EXTERNAL_NUM_INTERRUPTS];
+static voidFuncPtr ISRcallback[EXTERNAL_NUM_INTERRUPTS];
+static EExt_Interrupts ISRlist[EXTERNAL_NUM_INTERRUPTS];
+static uint32_t nints; //stores total nr of attached interrupts
+
+//for debug
+voidFuncPtr* getISRcallback(){
+    return ISRcallback;
+}
+EExt_Interrupts* getISRlist(){
+    return ISRlist;
+}
+//end debug
+
+
 
 /* Configure I/O interrupt sources */
 static void __initialize()
 {
-  memset(callbacksInt, 0, sizeof(callbacksInt));
+  memset(ISRlist, 0, sizeof(ISRlist));
+  memset(ISRcallback, 0, sizeof(ISRcallback));
+  nints=0;
 
   NVIC_DisableIRQ(EIC_IRQn);
   NVIC_ClearPendingIRQ(EIC_IRQn);
@@ -76,41 +90,64 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
   // Assign pin to EIC
   pinPeripheral(pin, PIO_EXTINT);
 
-  // Assign callback to interrupt
-  callbacksInt[in] = callback;
+  if (callback){ //only store when there is really an ISR to call
+      //this allow for calling attachInterrupt(pin, NULL, mode), we set up all needed register
+      //but won't service the interrupt, this way we also don't need to check it inside the ISR
 
-  // Look for right CONFIG register to be addressed
-  if (in > EXTERNAL_INT_7) {
-    config = 1;
-  } else {
-    config = 0;
+    // Store interrupts to service in order of when they were attached
+    // to allow for first come first serve handler
+    uint32_t current=0;
+    //check if we already have this interrupt
+    int id=-1;
+    for (uint32_t i=0; i<nints; i++){
+      if (ISRlist[i]==in) id=in;
+    }
+
+    if (id==-1){
+      //need to make a new entry
+      current=nints;
+      nints++;
+    }
+    else{
+      //we already have an entry for this pin
+      current=id;
+    }
+    ISRlist[current]=in; //list with nr of interrupt in order of when they were attached
+    ISRcallback[current]=callback; //list of callback adresses
+
+    // Look for right CONFIG register to be addressed
+    if (in > EXTERNAL_INT_7) {
+        config = 1;
+    } else {
+        config = 0;
+    }
+
+    // Configure the interrupt mode
+    pos = (in - (8 * config)) << 2;
+    EIC->CONFIG[config].reg &=~ (EIC_CONFIG_SENSE0_Msk << pos);//reset sense mode, important when changing trigger mode during runtime
+    switch (mode)
+    {
+      case LOW:
+        EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_LOW_Val << pos;
+        break;
+
+      case HIGH:
+        EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_HIGH_Val << pos;
+        break;
+
+      case CHANGE:
+        EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_BOTH_Val << pos;
+        break;
+
+      case FALLING:
+        EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_FALL_Val << pos;
+        break;
+
+        case RISING:
+        EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_RISE_Val << pos;
+        break;
+    }
   }
-
-  // Configure the interrupt mode
-  pos = (in - (8 * config)) << 2;
-  switch (mode)
-  {
-    case LOW:
-      EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_LOW_Val << pos;
-      break;
-
-    case HIGH:
-      EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_HIGH_Val << pos;
-      break;
-
-    case CHANGE:
-      EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_BOTH_Val << pos;
-      break;
-
-    case FALLING:
-      EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_FALL_Val << pos;
-      break;
-
-    case RISING:
-      EIC->CONFIG[config].reg |= EIC_CONFIG_SENSE0_RISE_Val << pos;
-      break;
-  }
-
   // Enable the interrupt
   EIC->INTENSET.reg = EIC_INTENSET_EXTINT(1 << in);
 }
@@ -132,6 +169,21 @@ void detachInterrupt(uint32_t pin)
   
   // Disable wakeup capability on pin during sleep
   EIC->WAKEUP.reg &= ~(1 << in);
+
+  //and take it out of the ISR list
+  int id=-1; //find its location first
+  for (uint32_t i=0; i<nints; i++){
+      if (ISRlist[i]==in) id=in;
+  }
+  if (id==-1) return; //apparently we didn't have it
+  for (uint32_t i=id; i<nints-1; i++){ //and shift the ones above one down
+      ISRlist[i]=ISRlist[i+1];
+      ISRcallback[i]=ISRcallback[i+1];
+  }
+  //and remove the top item
+  ISRlist[nints]=0;
+  ISRcallback[nints]=NULL;
+  nints--;
 }
 
 /*
@@ -139,18 +191,15 @@ void detachInterrupt(uint32_t pin)
  */
 void EIC_Handler(void)
 {
-  // Test the 16 normal interrupts
-  for (uint32_t i=EXTERNAL_INT_0; i<=EXTERNAL_INT_15; i++)
-  {
-    if ((EIC->INTFLAG.reg & (1 << i)) != 0)
-    {
-      // Call the callback function if assigned
-      if (callbacksInt[i]) {
-        callbacksInt[i]();
-      }
-
-      // Clear the interrupt
-      EIC->INTFLAG.reg = 1 << i;
+  //calling the routine directly from -here- takes about 1us
+  //depending on where you are in the list it will take longer
+  for (uint32_t i=0; i<nints; i++) // Loop over all enabled interrupts in the list
+  {  
+    if ((EIC->INTFLAG.reg & 1<<ISRlist[i]) != 0)
+    {  
+      ISRcallback[i]();// Call the callback function if assigned
+      EIC->INTFLAG.reg = 1<<ISRlist[i]; // Clear the interrupt
     }
   }
+
 }

--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -42,6 +42,9 @@ typedef void (*voidFuncPtr)(void);
  */
 void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode);
 
+voidFuncPtr* getISRcallback();// for debug only, remove
+EExt_Interrupts* getISRlist();//for debug only, remove
+
 /*
  * \brief Turns off the given interrupt.
  */


### PR DESCRIPTION
line 127 fixes an issues when changing trigger mode during runtime

rest is to improve speed of interrupt from 6us for an extint14 to below
2us now.
The interrupt handler is now based on a first come first serve policy
which serves first the ISR that was attached first  and it only tries
to service ISRs that were actually attached.